### PR TITLE
Remove unused code that prevented compilation

### DIFF
--- a/src/acheron.asm
+++ b/src/acheron.asm
@@ -33,13 +33,6 @@ ZPVAR rptr, regs, 1, "Pointer to the head of the register stack, which is also r
 ZPVAR pptr, regs, 1, "Pointer to the prior register, rP."
 
 
-.macro reportSize label, filename
- label:
- .include filename
- .ident (.concat("_size__", .string(label))) = * - name
- .export .ident (.concat("_size__", .string(label)))
- .endmacro
- 
 .macro reportSizeSince name
  :
  .ident (.concat("_size__", .string(name))) = :- - name


### PR DESCRIPTION
Using .include inside a macro resolves the included file at definition time.
The removed code was assuming (correctly for an older version of ca65), that the include was being resolved at usage time.
As this code now breaks compilation, it must be removed. It wasn't being used anyways.